### PR TITLE
Fix autoconf issues with Xcode 12

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -90,7 +90,7 @@ AC_CACHE_VAL(ac_cv_ipv4,
 		int fd;
 		struct sockaddr_in foo;
 		fd = socket(AF_INET, SOCK_STREAM, 0);
-		exit(fd >= 0 ? 0 : 1);
+		return fd >= 0 ? 0 : 1;
 	}]])],[ac_cv_ipv4=yes],[ac_cv_ipv4=no],[ac_cv_ipv4=no]))
 AC_MSG_RESULT($ac_cv_ipv4)
 if test $ac_cv_ipv4 = yes ; then
@@ -113,7 +113,7 @@ AC_CACHE_VAL(ac_cv_ipv6,
 		int fd;
 		struct sockaddr_in6 foo;
 		fd = socket(AF_INET6, SOCK_STREAM, 0);
-		exit(fd >= 0 ? 0 : 1);
+		return fd >= 0 ? 0 : 1;
 	}]])],[ac_cv_ipv6=yes],[ac_cv_ipv6=no],[ac_cv_ipv6=no]))
 AC_MSG_RESULT($ac_cv_ipv6)
 if test $ac_cv_ipv6 = yes ; then
@@ -259,8 +259,8 @@ AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <signal.h>
 main()
 {
-	char *s = sys_siglist[0];
-	exit(0);
+	const char *s = sys_siglist[0];
+	return 0;
 }
 ]])],[AC_MSG_RESULT(yes) 
   sys_siglist="1"
@@ -363,7 +363,7 @@ dnl ----------------------------------------------------------
 AX_CHECK_OPENSSL([
 	AC_DEFINE(HAVE_SSL, 1, Defined if your system has OpenSSL)
     ], [
-	AC_ERROR(failed to find OpenSSL)
+	AC_MSG_ERROR([failed to find OpenSSL])
     ])
 
 

--- a/sa.ac
+++ b/sa.ac
@@ -76,17 +76,17 @@ int main(void)
     timeo.tv_usec = 3;
 
 #ifndef $1
-    exit(3);
+    return 3;
 #else
     if ((s = socket(PF_INET, SOCK_STREAM, 0)) == -1)
-        exit(2);
+        return 2;
 
     /* fails on Solaris 2.6,8,9,10 and Debian 2.2 because
        SO_RCVTIMEO|SO_SNDTIMEO are defined but not implemented */
     if (setsockopt(s, SOL_SOCKET, $1, (void *)&timeo, sizeof(timeo)) == -1)
-        exit(1);
+        return 1;
 
-    exit(0);
+    return 0;
 #endif
 }
 


### PR DESCRIPTION
On recent versions of Xcode, calling an implicitly defined function is now an error by default (matching C++'s behavior)  Since most compilers have warned about this for ages it's not usually a problem.  However it is very common that autoconf scripts will generate warnings that nobody looks at.

One of the easiest ways to trigger this is to call `exit()` without #include `<stdlib.h>`.  However the simplest fix is usually
to just use `return` instead.

Also switch to modern `AC_MSG_ERROR` instead of `AC_ERROR` and fix a `const` issue that was breaking `sys_siglist[]` detection for me.