### PR TITLE
Fix ODR violation caused by ircterm.h

### DIFF
--- a/ircterm.h
+++ b/ircterm.h
@@ -61,9 +61,9 @@ int term_eight_bit(void);
 void term_set_eight_bit(int value);
 
 /* strange function pointers, filled in at runtime */
-int (*term_scroll) (int, int, int);	/* best scroll available */
-int (*term_insert) (char);	/* best insert available */
-int (*term_delete) (void);	/* best delete available */
-int (*term_cursor_left) (void);	/* best left available */
+extern int (*term_scroll) (int, int, int);	/* best scroll available */
+extern int (*term_insert) (char);	/* best insert available */
+extern int (*term_delete) (void);	/* best delete available */
+extern int (*term_cursor_left) (void);	/* best left available */
 
 #endif				/* ircterm_h__ */


### PR DESCRIPTION
These statements are interpreted as definitions and create independent instances in each object files, and will conflict at the link stage, which causes https://github.com/Homebrew/homebrew-core/pull/115340 to fail to build.